### PR TITLE
improve UI Tests stability

### DIFF
--- a/SpartaConnect.xcodeproj/project.pbxproj
+++ b/SpartaConnect.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		302D1458B2EB23D6A2F0ED09 /* Pods_AppSpecs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A32BB0827C211B805B4B16F /* Pods_AppSpecs.framework */; };
+		4A1C9281249739A600E52F6A /* XCTWaiter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1C9280249739A600E52F6A /* XCTWaiter+Extension.swift */; };
 		4A1DCC58249031320014E9CF /* OpenAtLoginTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DCC57249031320014E9CF /* OpenAtLoginTest.swift */; };
 		4A3F3C76248C92720058C5D4 /* Testable.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A3F3C74248C92720058C5D4 /* Testable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4A3F3C79248C92720058C5D4 /* Testable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A3F3C72248C92720058C5D4 /* Testable.framework */; };
@@ -77,6 +78,7 @@
 		1752C341CDE3B953C9942626 /* Pods-AppSpecs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppSpecs.release.xcconfig"; path = "Target Support Files/Pods-AppSpecs/Pods-AppSpecs.release.xcconfig"; sourceTree = "<group>"; };
 		18383CF04CD5A0B420B6B253 /* Pods-AppSpecs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppSpecs.debug.xcconfig"; path = "Target Support Files/Pods-AppSpecs/Pods-AppSpecs.debug.xcconfig"; sourceTree = "<group>"; };
 		4275614E6C55701F69F0E518 /* Pods_UITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A1C9280249739A600E52F6A /* XCTWaiter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTWaiter+Extension.swift"; sourceTree = "<group>"; };
 		4A1DC8D06D85415B5E5370B8 /* Pods-UnitSpecs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitSpecs.release.xcconfig"; path = "Target Support Files/Pods-UnitSpecs/Pods-UnitSpecs.release.xcconfig"; sourceTree = "<group>"; };
 		4A1DCC57249031320014E9CF /* OpenAtLoginTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAtLoginTest.swift; sourceTree = "<group>"; };
 		4A3F3C72248C92720058C5D4 /* Testable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Testable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -224,6 +226,7 @@
 			isa = PBXGroup;
 			children = (
 				4AD40A9624884D9D002728DA /* XCUIElement+Extension.swift */,
+				4A1C9280249739A600E52F6A /* XCTWaiter+Extension.swift */,
 				4A3F3C9A249074EF0058C5D4 /* XCUIApplication+Extension.swift */,
 				4A3F3C94248F60150058C5D4 /* TempAppHelper.swift */,
 				4A8A3636249638100071624E /* LaunchService.swift */,
@@ -714,6 +717,7 @@
 				4A3F3C9B249074EF0058C5D4 /* XCUIApplication+Extension.swift in Sources */,
 				4A1DCC58249031320014E9CF /* OpenAtLoginTest.swift in Sources */,
 				4AA188AB2486FA90009CFACE /* UpdateAppTest.swift in Sources */,
+				4A1C9281249739A600E52F6A /* XCTWaiter+Extension.swift in Sources */,
 				4A3F3C95248F60150058C5D4 /* TempAppHelper.swift in Sources */,
 				4AD40A9724884D9D002728DA /* XCUIElement+Extension.swift in Sources */,
 				4ABB7A8C248EB8A7009128E3 /* MoveToApplicationsTest.swift in Sources */,

--- a/SpartaConnect.xcodeproj/project.pbxproj
+++ b/SpartaConnect.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		4AA188912486FA90009CFACE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4AA188902486FA90009CFACE /* Assets.xcassets */; };
 		4AA188942486FA90009CFACE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4AA188922486FA90009CFACE /* Main.storyboard */; };
 		4AA188AB2486FA90009CFACE /* UpdateAppTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA188AA2486FA90009CFACE /* UpdateAppTest.swift */; };
-		4ABB7A8C248EB8A7009128E3 /* MoveToApplicationsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABB7A8B248EB8A7009128E3 /* MoveToApplicationsTest.swift */; };
+		4ABB7A8C248EB8A7009128E3 /* ZMoveToApplicationsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABB7A8B248EB8A7009128E3 /* ZMoveToApplicationsTest.swift */; };
 		4AD40A9124870708002728DA /* FirstSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD40A9024870708002728DA /* FirstSpec.swift */; };
 		4AD40A9724884D9D002728DA /* XCUIElement+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD40A9624884D9D002728DA /* XCUIElement+Extension.swift */; };
 		4BC13F50249409D000360A26 /* StatusBarMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC13F4F249409D000360A26 /* StatusBarMenu.swift */; };
@@ -110,7 +110,7 @@
 		4AA188A62486FA90009CFACE /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AA188AA2486FA90009CFACE /* UpdateAppTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAppTest.swift; sourceTree = "<group>"; };
 		4AA188AC2486FA90009CFACE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		4ABB7A8B248EB8A7009128E3 /* MoveToApplicationsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveToApplicationsTest.swift; sourceTree = "<group>"; };
+		4ABB7A8B248EB8A7009128E3 /* ZMoveToApplicationsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMoveToApplicationsTest.swift; sourceTree = "<group>"; };
 		4AD40A9024870708002728DA /* FirstSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSpec.swift; sourceTree = "<group>"; };
 		4AD40A9224870C00002728DA /* ci.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; name = ci.yml; path = .github/workflows/ci.yml; sourceTree = "<group>"; };
 		4AD40A9624884D9D002728DA /* XCUIElement+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Extension.swift"; sourceTree = "<group>"; };
@@ -293,7 +293,7 @@
 			children = (
 				4AA188AA2486FA90009CFACE /* UpdateAppTest.swift */,
 				4A1DCC57249031320014E9CF /* OpenAtLoginTest.swift */,
-				4ABB7A8B248EB8A7009128E3 /* MoveToApplicationsTest.swift */,
+				4ABB7A8B248EB8A7009128E3 /* ZMoveToApplicationsTest.swift */,
 				4A3F3C99248F607F0058C5D4 /* Supporting Files */,
 			);
 			path = UITests;
@@ -720,7 +720,7 @@
 				4A1C9281249739A600E52F6A /* XCTWaiter+Extension.swift in Sources */,
 				4A3F3C95248F60150058C5D4 /* TempAppHelper.swift in Sources */,
 				4AD40A9724884D9D002728DA /* XCUIElement+Extension.swift in Sources */,
-				4ABB7A8C248EB8A7009128E3 /* MoveToApplicationsTest.swift in Sources */,
+				4ABB7A8C248EB8A7009128E3 /* ZMoveToApplicationsTest.swift in Sources */,
 				4A3F3C97248F604B0058C5D4 /* FileHelper.swift in Sources */,
 				4A3F3CA32490CD740058C5D4 /* BundleHelper.swift in Sources */,
 				4A8A3637249638100071624E /* LaunchService.swift in Sources */,

--- a/UITests/FileHelper.swift
+++ b/UITests/FileHelper.swift
@@ -10,7 +10,13 @@ class FileHelper {
     }
     
     func copy(_ from: URL, to destination: URL) {
-        try! fileManager.copyItem(at: from, to: destination)
+        let duplicated = XCTestExpectation(description: "duplicated")
+        NSWorkspace.shared.duplicate([from]) { (map, error) in
+            XCTAssertNil(error)
+            _ = try! self.fileManager.replaceItemAt(destination, withItemAt: map[from]!, backupItemName: nil, options: .usingNewMetadataOnly)
+            duplicated.fulfill()
+        }
+        XCTWaiter.wait(until: duplicated, timeout: .install, "should copy")
         XCTAssertTrue(fileManager.fileExists(atPath: destination.path))
     }
     

--- a/UITests/FileHelper.swift
+++ b/UITests/FileHelper.swift
@@ -35,4 +35,27 @@ class FileHelper {
             return list.contains { ($0 as? URL)?.lastPathComponent == file }
         }
     }
+    
+    func applications(home: URL) -> URL {
+        home.appendingPathComponent("Applications")
+    }
+    
+    func hasFilesIn(url: URL) -> Bool {
+        if let list = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: nil,
+            options: []) {
+            return list.count > 1
+        }
+        return false
+    }
+    
+    func preferredApplicationsUrl() -> URL {
+        let home = fileManager.homeDirectoryForCurrentUser
+        let userAppsUrl = applications(home: home)
+        if hasFilesIn(url: userAppsUrl) {
+            return userAppsUrl
+        }
+        return applications(home: URL(fileURLWithPath: "/"))
+    }
 }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -18,7 +18,8 @@ enum LaunchService {
         XCTAssertEqual(kUTTypeApplicationBundle as String, fileType)
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
-        XCTWaiter.wait(for: ready)
+        XCTWaiter.wait(until: ready, timeout: .install,
+                       "app is not ready for launch at: \(url)")
         let values = try! url.resourceValues(forKeys: [.quarantinePropertiesKey])
         XCTAssertNil(values.quarantineProperties, "should have no quarantine properties")
     }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -14,7 +14,7 @@ enum LaunchService {
     static func waitForAppToBeReadyForLaunch(at url: URL) {
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
-        XCTWaiter().wait(for: [ready], timeout: Timeout.test.rawValue)
+        XCTWaiter.wait(until: ready, "app is not ready for launch at: \(url)")
         let values = try! url.resourceValues(forKeys: [.quarantinePropertiesKey])
         XCTAssertNil(values.quarantineProperties, "should have no quarantine properties")
     }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -14,8 +14,7 @@ enum LaunchService {
     static func waitForAppToBeReadyForLaunch(at url: URL) {
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
-        XCTWaiter.wait(until: ready, timeout: .install,
-                       "app is not ready for launch at: \(url)")
+        XCTWaiter.wait(for: ready)
         let values = try! url.resourceValues(forKeys: [.quarantinePropertiesKey])
         XCTAssertNil(values.quarantineProperties, "should have no quarantine properties")
     }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -2,16 +2,20 @@ import XCTest
 
 enum LaunchService {
     private static func isReadyToBeLaunched() -> NSPredicate {
-        NSPredicate { object, _  in
+        let workspace = NSWorkspace.shared
+        return NSPredicate { object, _  in
             if let appUrl = object as? URL,
-                let url = LSCopyDefaultApplicationURLForURL(appUrl as CFURL, .all, nil) {
-                return (url.takeRetainedValue() as URL) == appUrl
+                let url = workspace.urlForApplication(toOpen: appUrl) {
+                return url == appUrl
             }
             return false
         }
     }
 
     static func waitForAppToBeReadyForLaunch(at url: URL) {
+        let workspace = NSWorkspace.shared
+        let fileType = try! workspace.type(ofFile: url.path)
+        XCTAssertEqual(kUTTypeApplicationBundle as String, fileType)
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
         XCTWaiter.wait(for: ready)

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -14,7 +14,8 @@ enum LaunchService {
     static func waitForAppToBeReadyForLaunch(at url: URL) {
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
-        XCTWaiter.wait(until: ready, "app is not ready for launch at: \(url)")
+        XCTWaiter.wait(until: ready, timeout: .install,
+                       "app is not ready for launch at: \(url)")
         let values = try! url.resourceValues(forKeys: [.quarantinePropertiesKey])
         XCTAssertNil(values.quarantineProperties, "should have no quarantine properties")
     }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -14,7 +14,7 @@ enum LaunchService {
     static func waitForAppToBeReadyForLaunch(at url: URL) {
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
-        XCTWaiter().wait(for: [ready], timeout: kDefaultTimeout)
+        XCTWaiter().wait(for: [ready], timeout: Timeout.test.rawValue)
         let values = try! url.resourceValues(forKeys: [.quarantinePropertiesKey])
         XCTAssertNil(values.quarantineProperties, "should have no quarantine properties")
     }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -15,5 +15,7 @@ enum LaunchService {
         let ready = XCTNSPredicateExpectation(predicate: isReadyToBeLaunched(),
                                               object: url)
         XCTWaiter().wait(for: [ready], timeout: kDefaultTimeout)
+        let values = try! url.resourceValues(forKeys: [.quarantinePropertiesKey])
+        XCTAssertNil(values.quarantineProperties, "should have no quarantine properties")
     }
 }

--- a/UITests/LaunchService.swift
+++ b/UITests/LaunchService.swift
@@ -6,8 +6,10 @@ enum LaunchService {
         return NSPredicate { object, _  in
             if let appUrl = object as? URL,
                 let url = workspace.urlForApplication(toOpen: appUrl) {
+                NSLog("url:\(url), appUrl: \(appUrl)")
                 return url == appUrl
             }
+            NSLog("no app for url:\(object)")
             return false
         }
     }

--- a/UITests/MoveToApplicationsTest.swift
+++ b/UITests/MoveToApplicationsTest.swift
@@ -23,8 +23,7 @@ class MoveToApplicationsTest: XCTestCase {
     
     func launchAndChooseToMoveToApplications() {
         tempApp.launch()
-        let alert = tempApp.dialogs["alert"]
-        alert.staticTexts["Move to Applications folder?"].waitToAppear()
+        let alert = tempApp.waitForMoveAlert()
         alert.buttons["Move to Applications Folder"].click()
         alert.waitToDisappear()
         tempApp.wait(until: .notRunning, "wait for app to terminate")

--- a/UITests/MoveToApplicationsTest.swift
+++ b/UITests/MoveToApplicationsTest.swift
@@ -17,8 +17,7 @@ class MoveToApplicationsTest: XCTestCase {
     }
     
     func verifyRunningFromApplications() {
-        XCTAssertTrue(movedApp.wait(for: .runningBackground, timeout: 5),
-                      "wait for app to restart from /Applications")
+        movedApp.wait(until: .runningBackground, "wait for app to restart from /Applications")
         movedApp.terminate()
     }
     
@@ -28,7 +27,7 @@ class MoveToApplicationsTest: XCTestCase {
         alert.staticTexts["Move to Applications folder?"].waitToAppear()
         alert.buttons["Move to Applications Folder"].click()
         alert.waitToDisappear()
-        XCTAssertTrue(tempApp.wait(for: .notRunning, timeout: 1), "wait for app to terminate")
+        tempApp.wait(until: .notRunning, "wait for app to terminate")
     }
     
     func testMoveToApplications() throws {

--- a/UITests/TempAppHelper.swift
+++ b/UITests/TempAppHelper.swift
@@ -49,7 +49,27 @@ class TempAppHelper {
 }
 
 class MoveAppHelper: TempAppHelper {
-    let movedUrl = URL(fileURLWithPath: "/Applications/SpartaConnect.app")
+    static func applications(home: URL) -> URL {
+        home.appendingPathComponent("Applications")
+    }
+    // TODO: pz - refactor to fileHelper
+    static func preferredApplicationsUrl() -> URL {
+        let fileManager = FileManager.default
+
+        let home = fileManager.homeDirectoryForCurrentUser
+        let apps = applications(home: home)
+        if let list = try? fileManager.contentsOfDirectory(at: apps, includingPropertiesForKeys: nil, options: []), list.count > 1 {
+            return apps
+        }
+        return applications(home: URL(fileURLWithPath: "/"))
+    }
+    override init() {
+        movedUrl = Self.preferredApplicationsUrl()
+            .appendingPathComponent("SpartaConnect.app")
+        super.init()
+    }
+    private let movedUrl: URL
+
     func movedApp() -> XCUIApplication {
         XCUIApplication(url: movedUrl)
     }

--- a/UITests/TempAppHelper.swift
+++ b/UITests/TempAppHelper.swift
@@ -51,7 +51,6 @@ class TempAppHelper {
         let original = XCUIApplication().url
         NSLog("original app: \(original)")
         fileHelper.copy(original, to: tempUrl)
-//        LaunchService.waitForAppToBeReadyForLaunch(at: tempUrl)
     }
     private func removeTempApp() {
         fileHelper.remove(url: tempUrl)

--- a/UITests/TempAppHelper.swift
+++ b/UITests/TempAppHelper.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class TempAppHelper {
-    let tempUrl = URL(fileURLWithPath: "/tmp/SpartaConnect.app")
+    let tempUrl = URL(fileURLWithPath: "/tmp/SpartaConnect-\(arc4random()).app")
     let bundleHelper = BundleHelper(bundleId: "com.spartascience.SpartaConnect")
     let fileHelper = FileHelper()
     var removeMonitor: (()->Void)!
@@ -35,7 +35,9 @@ class TempAppHelper {
         }
         removeMonitor = {test.removeUIInterruptionMonitor(openFirstTimeMonitor)}
         removeTempApp()
-        fileHelper.copy(XCUIApplication().url, to: tempUrl)
+        let original = XCUIApplication().url
+        NSLog("original app: \(original)")
+        fileHelper.copy(original, to: tempUrl)
         LaunchService.waitForAppToBeReadyForLaunch(at: tempUrl)
     }
     private func removeTempApp() {
@@ -51,7 +53,7 @@ class TempAppHelper {
 class MoveAppHelper: TempAppHelper {
     lazy var movedUrl = fileHelper
         .preferredApplicationsUrl()
-        .appendingPathComponent("SpartaConnect.app")
+        .appendingPathComponent(tempUrl.lastPathComponent)
 
     func movedApp() -> XCUIApplication {
         XCUIApplication(url: movedUrl)

--- a/UITests/TempAppHelper.swift
+++ b/UITests/TempAppHelper.swift
@@ -49,26 +49,9 @@ class TempAppHelper {
 }
 
 class MoveAppHelper: TempAppHelper {
-    static func applications(home: URL) -> URL {
-        home.appendingPathComponent("Applications")
-    }
-    // TODO: pz - refactor to fileHelper
-    static func preferredApplicationsUrl() -> URL {
-        let fileManager = FileManager.default
-
-        let home = fileManager.homeDirectoryForCurrentUser
-        let apps = applications(home: home)
-        if let list = try? fileManager.contentsOfDirectory(at: apps, includingPropertiesForKeys: nil, options: []), list.count > 1 {
-            return apps
-        }
-        return applications(home: URL(fileURLWithPath: "/"))
-    }
-    override init() {
-        movedUrl = Self.preferredApplicationsUrl()
-            .appendingPathComponent("SpartaConnect.app")
-        super.init()
-    }
-    private let movedUrl: URL
+    lazy var movedUrl = fileHelper
+        .preferredApplicationsUrl()
+        .appendingPathComponent("SpartaConnect.app")
 
     func movedApp() -> XCUIApplication {
         XCUIApplication(url: movedUrl)

--- a/UITests/TempAppHelper.swift
+++ b/UITests/TempAppHelper.swift
@@ -22,8 +22,8 @@ class TempAppHelper {
         let openFirstTimeMonitor = test.addUIInterruptionMonitor(
             withDescription: "open first time"
         ) { alert -> Bool in
-            print(alert)
             if alert.buttons["Show Application"].exists {
+                NSLog("alert: " + alert.debugDescription)
                 XCTAssertTrue(alert.staticTexts[
                     "You are opening the application “SpartaConnect” for the first time. "
                         + "Are you sure you want to open this application?"

--- a/UITests/TempAppHelper.swift
+++ b/UITests/TempAppHelper.swift
@@ -17,6 +17,19 @@ class TempAppHelper {
         bundleHelper.find(file: fileName,
                           inCache: "org.sparkle-project.Sparkle/PersistentDownloads")
     }
+
+    func launch(arguments:[String] = []) {
+        let workspace = NSWorkspace.shared
+        let config = NSWorkspace.OpenConfiguration()
+        config.arguments = arguments
+        let running = XCTestExpectation(description: "running")
+        running.assertForOverFulfill = true
+        workspace.open(tempUrl, configuration: config) { app, err in
+            running.fulfill()
+            XCTAssertNil(err)
+        }
+        XCTWaiter.wait(until: running, "should be running")
+    }
     
     func prepare(for test: XCTestCase) {
         let openFirstTimeMonitor = test.addUIInterruptionMonitor(
@@ -38,7 +51,7 @@ class TempAppHelper {
         let original = XCUIApplication().url
         NSLog("original app: \(original)")
         fileHelper.copy(original, to: tempUrl)
-        LaunchService.waitForAppToBeReadyForLaunch(at: tempUrl)
+//        LaunchService.waitForAppToBeReadyForLaunch(at: tempUrl)
     }
     private func removeTempApp() {
         fileHelper.remove(url: tempUrl)

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -37,7 +37,7 @@ class UpdateAppTest: XCTestCase {
     
     func installAndRelaunch() {
         let updatingWindow = app.windows["Updating SpartaConnect"]
-        updatingWindow.waitToAppear(timeout: 5 * kDefaultTimeout)
+        updatingWindow.waitToAppear()
         updatingWindow.staticTexts["Ready to Install"].waitToAppear(timeout: 5 * kDefaultTimeout)
         let appUrl = app.url
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -37,7 +37,7 @@ class UpdateAppTest: XCTestCase {
     
     func installAndRelaunch() {
         let updatingWindow = app.windows["Updating SpartaConnect"]
-        updatingWindow.waitToAppear(timeout: 2 * kDefaultTimeout)
+        updatingWindow.waitToAppear(timeout: 5 * kDefaultTimeout)
         updatingWindow.staticTexts["Ready to Install"].waitToAppear()
         let appUrl = app.url
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -96,7 +96,7 @@ class UpdateAppTest: XCTestCase {
         app.activate()
         app.clickStatusItem()
         app.statusBarMenu().menuItems["Quit SpartaConnect"].click()
-        app.wait(until: .notRunning, timeout: 5 * kDefaultTimeout)
+        app.wait(until: .notRunning, timeout: Timeout.install.rawValue)
     }
     
     func checkUpdateDownloaded() -> NSPredicate {
@@ -104,8 +104,9 @@ class UpdateAppTest: XCTestCase {
     }
     
     func waitForUpdatesDownloaded() {
-        let downloadComplete = expectation(for: checkUpdateDownloaded(), evaluatedWith: nil)
-        let downloadTimeout = 20 * kDefaultTimeout
+        let downloadComplete = expectation(for: checkUpdateDownloaded(),
+                                           evaluatedWith: nil)
+        let downloadTimeout = 2 * Timeout.network.rawValue
         wait(for: [downloadComplete], timeout: downloadTimeout)
     }
     
@@ -114,8 +115,7 @@ class UpdateAppTest: XCTestCase {
             notPredicateWithSubpredicate: checkUpdateDownloaded()
         )
         let expectDownload = expectation(for: downloadedDeleted, evaluatedWith: nil)
-        let installTimeout = 5 * kDefaultTimeout
-        wait(for: [expectDownload], timeout: installTimeout)
+        wait(for: [expectDownload], timeout: Timeout.install.rawValue)
     }
     
     func checkForUpdatesAndInstallOnQuit() {

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -48,7 +48,7 @@ class UpdateAppTest: XCTestCase {
             agent.activate()
             let predicate = NSPredicate(format: "title == Open")
             let button = agent.buttons.matching(predicate).element
-            if button.exists {
+            if agent.state != .notRunning, button.exists {
                 NSLog("agent: " + agent.debugDescription)
                 button.click()
             }

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -38,7 +38,7 @@ class UpdateAppTest: XCTestCase {
     func installAndRelaunch() {
         let updatingWindow = app.windows["Updating SpartaConnect"]
         updatingWindow.waitToAppear(timeout: 5 * kDefaultTimeout)
-        updatingWindow.staticTexts["Ready to Install"].waitToAppear()
+        updatingWindow.staticTexts["Ready to Install"].waitToAppear(timeout: 5 * kDefaultTimeout)
         let appUrl = app.url
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()
         app.wait(until: .notRunning, "wait for app to terminate")

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -47,8 +47,7 @@ class UpdateAppTest: XCTestCase {
     }
     
     func dismissMoveToApplicationsAlert() {
-        let alert = app.dialogs["alert"]
-        alert.staticTexts["Move to Applications folder?"].waitToAppear()
+        let alert = app.waitForMoveAlert()
         alert.buttons["Do Not Move"].click()
         alert.waitToDisappear()
     }

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -1,7 +1,5 @@
 import XCTest
 
-let kDefaultTimeout: TimeInterval = 5
-
 enum Timeout: TimeInterval {
     case test = 5
     case launch = 10
@@ -71,7 +69,7 @@ class UpdateAppTest: XCTestCase {
     
     
     func verifyUpdated() {
-        app.wait(until: .runningForeground, timeout: 5, "wait for app to relaunch")
+        app.wait(until: .runningForeground, "wait for app to relaunch")
         app.windows["Window"].waitToAppear(time: .launch)
         app.menuBars.menuBarItems["SpartaConnect"].click()
         app.menuBars.menus.menuItems["About SpartaConnect"].click()
@@ -96,7 +94,7 @@ class UpdateAppTest: XCTestCase {
         app.activate()
         app.clickStatusItem()
         app.statusBarMenu().menuItems["Quit SpartaConnect"].click()
-        app.wait(until: .notRunning, timeout: Timeout.install.rawValue)
+        app.wait(until: .notRunning, timeout: .install)
     }
     
     func checkUpdateDownloaded() -> NSPredicate {

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -38,8 +38,10 @@ class UpdateAppTest: XCTestCase {
     func installAndRelaunch() {
         let updatingWindow = app.windows["Updating SpartaConnect"]
         updatingWindow.staticTexts["Ready to Install"].waitToAppear()
+        let appUrl = app.url
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()
         app.wait(until: .notRunning, "wait for app to terminate")
+        LaunchService.waitForAppToBeReadyForLaunch(at: appUrl)
         app.wait(until: .runningForeground, "wait for app to relaunch")
     }
     

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -60,7 +60,7 @@ class UpdateAppTest: XCTestCase {
                 NSLog("agent: " + agent.debugDescription)
                 button.click()
             }
-        } while !app.wait(for: .runningForeground, timeout: kDefaultTimeout)
+        } while !app.wait(for: .runningForeground)
     }
     
     func dismissMoveToApplicationsAlert() {

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -122,6 +122,7 @@ class UpdateAppTest: XCTestCase {
         checkForUpdatesAndInstallOnQuit()
         quitApp()
         waitForUpdatesInstalled()
+        LaunchService.waitForAppToBeReadyForLaunch(at: app.url)
         app.launch()
         app.wait(until: .runningForeground)
         verifyUpdated()

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -43,7 +43,16 @@ class UpdateAppTest: XCTestCase {
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()
         app.wait(until: .notRunning, "wait for app to terminate")
         LaunchService.waitForAppToBeReadyForLaunch(at: appUrl)
-        app.wait(until: .runningForeground, "wait for app to relaunch")
+        let agent = XCUIApplication(bundleIdentifier: "com.apple.coreservices.uiagent")
+        repeat {
+            agent.activate()
+            let predicate = NSPredicate(format: "title == Open")
+            let button = agent.buttons.matching(predicate).element
+            if button.exists {
+                NSLog("agent: " + agent.debugDescription)
+                button.click()
+            }
+        } while !app.wait(for: .runningForeground, timeout: kDefaultTimeout)
     }
     
     func dismissMoveToApplicationsAlert() {

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -37,6 +37,7 @@ class UpdateAppTest: XCTestCase {
     
     func installAndRelaunch() {
         let updatingWindow = app.windows["Updating SpartaConnect"]
+        updatingWindow.waitToAppear(timeout: 2 * kDefaultTimeout)
         updatingWindow.staticTexts["Ready to Install"].waitToAppear()
         let appUrl = app.url
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -2,6 +2,13 @@ import XCTest
 
 let kDefaultTimeout: TimeInterval = 5
 
+enum Timeout: TimeInterval {
+    case test = 5
+    case launch = 10
+    case install = 30
+    case network = 60
+}
+
 class UpdateAppTest: XCTestCase {
     let tempAppHelper = TempAppHelper()
     lazy var app = tempAppHelper.tempApp()
@@ -38,7 +45,8 @@ class UpdateAppTest: XCTestCase {
     func installAndRelaunch() {
         let updatingWindow = app.windows["Updating SpartaConnect"]
         updatingWindow.waitToAppear()
-        updatingWindow.staticTexts["Ready to Install"].waitToAppear(timeout: 5 * kDefaultTimeout)
+        updatingWindow.staticTexts["Ready to Install"]
+            .waitToAppear(time: .install)
         let appUrl = app.url
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()
         app.wait(until: .notRunning, "wait for app to terminate")
@@ -64,7 +72,7 @@ class UpdateAppTest: XCTestCase {
     
     func verifyUpdated() {
         app.wait(until: .runningForeground, timeout: 5, "wait for app to relaunch")
-        app.windows["Window"].waitToAppear(timeout: 3 * kDefaultTimeout)
+        app.windows["Window"].waitToAppear(time: .launch)
         app.menuBars.menuBarItems["SpartaConnect"].click()
         app.menuBars.menus.menuItems["About SpartaConnect"].click()
         app.dialogs.staticTexts["Version 1.0 (1.0.3)"].waitToAppear()

--- a/UITests/UpdateAppTest.swift
+++ b/UITests/UpdateAppTest.swift
@@ -39,8 +39,8 @@ class UpdateAppTest: XCTestCase {
         let updatingWindow = app.windows["Updating SpartaConnect"]
         updatingWindow.staticTexts["Ready to Install"].waitToAppear()
         updatingWindow.buttons["Install and Relaunch"].waitToAppear().click()
-        XCTAssertTrue(app.wait(for: .notRunning, timeout: kDefaultTimeout), "wait for app to terminate")
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: kDefaultTimeout), "wait for app to relaunch")
+        app.wait(until: .notRunning, "wait for app to terminate")
+        app.wait(until: .runningForeground, "wait for app to relaunch")
     }
     
     func dismissMoveToApplicationsAlert() {
@@ -52,7 +52,7 @@ class UpdateAppTest: XCTestCase {
     
     
     func verifyUpdated() {
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5), "wait for app to relaunch")
+        app.wait(until: .runningForeground, timeout: 5, "wait for app to relaunch")
         app.windows["Window"].waitToAppear(timeout: 3 * kDefaultTimeout)
         app.menuBars.menuBarItems["SpartaConnect"].click()
         app.menuBars.menus.menuItems["About SpartaConnect"].click()
@@ -64,9 +64,9 @@ class UpdateAppTest: XCTestCase {
         tempAppHelper.bundleHelper.persistDefaults([
             "SULastCheckTime": Date()
         ])
-        XCTAssertTrue(app.wait(for: .notRunning, timeout: kDefaultTimeout))
+        app.wait(until: .notRunning)
         app.launch()
-        XCTAssertTrue(app.wait(for: .runningBackground, timeout: kDefaultTimeout))
+        app.wait(until: .runningBackground)
         checkForUpdatesAndInstall()
         installAndRelaunch()
         dismissMoveToApplicationsAlert()
@@ -77,7 +77,7 @@ class UpdateAppTest: XCTestCase {
         app.activate()
         app.clickStatusItem()
         app.statusBarMenu().menuItems["Quit SpartaConnect"].click()
-        XCTAssertTrue(app.wait(for: .notRunning, timeout: 5 * kDefaultTimeout))
+        app.wait(until: .notRunning, timeout: 5 * kDefaultTimeout)
     }
     
     func checkUpdateDownloaded() -> NSPredicate {
@@ -115,13 +115,13 @@ class UpdateAppTest: XCTestCase {
     
     func testUpgradeOnQuit() {
         app.launch()
-        XCTAssertTrue(app.wait(for: .runningBackground, timeout: kDefaultTimeout))
+        app.wait(until: .runningBackground)
         waitForUpdatesDownloaded()
         checkForUpdatesAndInstallOnQuit()
         quitApp()
         waitForUpdatesInstalled()
         app.launch()
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: kDefaultTimeout))
+        app.wait(until: .runningForeground)
         verifyUpdated()
     }
 }

--- a/UITests/XCTWaiter+Extension.swift
+++ b/UITests/XCTWaiter+Extension.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+extension XCTWaiter {
+    @discardableResult
+    static func wait(for expectation: XCTestExpectation,
+                     timeout: Timeout = .test) -> XCTWaiter.Result {
+        self.init().wait(for: [expectation], timeout: timeout.rawValue)
+    }
+    
+    static func wait(until expectation: XCTestExpectation,
+                     timeout: Timeout = .test,
+                     _ reason: String,
+                     file: StaticString = #file,
+                     line: UInt = #line) {
+        XCTAssertEqual(wait(for: expectation, timeout: timeout),
+                       .completed, reason, file: file, line: line)
+    }
+}

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -18,11 +18,16 @@ extension XCUIApplication {
     func statusBarItem() -> XCUIElement {
         menuBars.statusItems.element
     }
+    
+    @discardableResult
+    func wait(for state: XCUIApplication.State, timeout: Timeout = .test) -> Bool {
+        wait(for: state, timeout: timeout.rawValue)
+    }
 
     func clickStatusItem() {
         repeat {
             statusBarItem().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
-        } while !statusBarMenu().waitForExistence(timeout: kDefaultTimeout)
+        } while !statusBarMenu().waitForExistence()
     }
     
     func wait(until newState: XCUIApplication.State,

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -21,6 +21,6 @@ extension XCUIApplication {
 
     func clickStatusItem() {
         activate()
-        statusBarItem().click()
+        statusBarItem().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
 }

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -16,12 +16,13 @@ extension XCUIApplication {
     }
 
     func statusBarItem() -> XCUIElement {
-        menuBars.statusItems.element
+        statusItems.element
     }
 
     func clickStatusItem() {
-        activate()
-        statusBarItem().waitToBeClickable().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        repeat {
+            statusBarItem().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        } while !statusBarMenu().waitForExistence(timeout: kDefaultTimeout)
     }
     
     func wait(until newState: XCUIApplication.State,

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -24,8 +24,16 @@ extension XCUIApplication {
         statusBarItem().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
     
-    func wait(until newState: XCUIApplication.State, timeout: TimeInterval = kDefaultTimeout, _ reason: String = "") {
-        XCTAssertTrue(wait(for: newState, timeout: timeout),
-                      reason + " got \(state.rawValue)")
+    func wait(until newState: XCUIApplication.State,
+              timeout: TimeInterval = kDefaultTimeout,
+              _ reason: String = "waiting for app state, ",
+              file: StaticString = #file,
+              line: UInt = #line) {
+        XCTAssertTrue(
+            wait(for: newState, timeout: timeout),
+            reason + " got \(state.rawValue)",
+            file: file,
+            line: line
+        )
     }
 }

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -21,7 +21,7 @@ extension XCUIApplication {
 
     func clickStatusItem() {
         activate()
-        statusBarItem().waitToBeClickable().click()
+        statusBarItem().waitToBeClickable().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
     
     func wait(until newState: XCUIApplication.State,

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -36,4 +36,12 @@ extension XCUIApplication {
             line: line
         )
     }
+
+    // MARK: Project specific
+
+    func waitForMoveAlert() -> XCUIElement {
+        let alert = dialogs["alert"]
+        alert.staticTexts["I can move myself to the Applications folder if you'd like."].waitToAppear()
+        return alert
+    }
 }

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -20,8 +20,7 @@ extension XCUIApplication {
     }
 
     func clickStatusItem() {
-        activate()
-        statusBarItem().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        statusBarItem().waitToBeClickable().click()
     }
     
     func wait(until newState: XCUIApplication.State,

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -20,6 +20,7 @@ extension XCUIApplication {
     }
 
     func clickStatusItem() {
+        activate()
         statusBarItem().waitToBeClickable().click()
     }
     

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -23,4 +23,9 @@ extension XCUIApplication {
         activate()
         statusBarItem().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
+    
+    func wait(until newState: XCUIApplication.State, timeout: TimeInterval = kDefaultTimeout, _ reason: String = "") {
+        XCTAssertTrue(wait(for: newState, timeout: timeout),
+                      reason + " got \(state.rawValue)")
+    }
 }

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -31,12 +31,12 @@ extension XCUIApplication {
     }
     
     func wait(until newState: XCUIApplication.State,
-              timeout: TimeInterval = kDefaultTimeout,
+              timeout: Timeout = .test,
               _ reason: String = "waiting for app state, ",
               file: StaticString = #file,
               line: UInt = #line) {
         XCTAssertTrue(
-            wait(for: newState, timeout: timeout),
+            wait(for: newState, timeout: timeout.rawValue),
             reason + " got \(state.rawValue)",
             file: file,
             line: line

--- a/UITests/XCUIApplication+Extension.swift
+++ b/UITests/XCUIApplication+Extension.swift
@@ -16,7 +16,7 @@ extension XCUIApplication {
     }
 
     func statusBarItem() -> XCUIElement {
-        statusItems.element
+        menuBars.statusItems.element
     }
 
     func clickStatusItem() {

--- a/UITests/XCUIElement+Extension.swift
+++ b/UITests/XCUIElement+Extension.swift
@@ -23,4 +23,18 @@ extension XCUIElement {
                       "\(self) has not appeared", file: file, line: line)
         return self
     }
+    @discardableResult
+    func waitToBeClickable(timeout: TimeInterval = kDefaultTimeout, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
+        let hittable = NSPredicate(format: "hittable == true")
+        let becameHittable = XCTNSPredicateExpectation(predicate: hittable, object: self)
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [becameHittable], timeout: timeout),
+            .completed,
+            "\(self) has not became hittable, isHittable:\(isHittable)",
+            file: file,
+            line: line
+        )
+        return self
+    }
+
 }

--- a/UITests/XCUIElement+Extension.swift
+++ b/UITests/XCUIElement+Extension.swift
@@ -16,13 +16,14 @@ extension XCUIElement {
                        "\(self) has not disappeared", file: file, line: line)
     }
     @discardableResult
-    func waitToAppear(timeout: TimeInterval = kDefaultTimeout,
+    func waitToAppear(time timeout: Timeout = .test,
                       file: StaticString = #file,
                       line: UInt = #line) -> XCUIElement{
-        XCTAssertTrue(waitForExistence(timeout: timeout),
+        XCTAssertTrue(waitForExistence(timeout: timeout.rawValue),
                       "\(self) has not appeared", file: file, line: line)
         return self
     }
+
     @discardableResult
     func waitToBeClickable(timeout: TimeInterval = kDefaultTimeout, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
         let hittable = NSPredicate(format: "hittable == true")

--- a/UITests/XCUIElement+Extension.swift
+++ b/UITests/XCUIElement+Extension.swift
@@ -8,12 +8,17 @@ extension XCUIElement {
         let firstLine = debugDescription[..<endOfLine]
         return firstLine.contains("label: '\(debugLabel)'")
     }
-    func waitToDisappear(timeout: TimeInterval = kDefaultTimeout, file: StaticString = #file, line: UInt = #line) {
+    func waitToDisappear(timeout: Timeout = .test,
+                         file: StaticString = #file, line: UInt = #line) {
         let doesNotExists = NSPredicate(format: "exists == false")
         let disappered = XCTNSPredicateExpectation(predicate: doesNotExists, object: self)
-        let waiter = XCTWaiter()
-        XCTAssertEqual(waiter.wait(for: [disappered], timeout: timeout), .completed,
-                       "\(self) has not disappeared", file: file, line: line)
+        XCTWaiter.wait(
+            until: disappered,
+            timeout: timeout,
+            "\(self) has not disappeared",
+            file: file,
+            line: line
+        )
     }
     
     @discardableResult
@@ -30,12 +35,14 @@ extension XCUIElement {
     }
 
     @discardableResult
-    func waitToBeClickable(timeout: TimeInterval = kDefaultTimeout, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
+    func waitToBeClickable(timeout: Timeout = .test,
+                           file: StaticString = #file,
+                           line: UInt = #line) -> XCUIElement {
         let hittable = NSPredicate(format: "hittable == true")
         let becameHittable = XCTNSPredicateExpectation(predicate: hittable, object: self)
-        XCTAssertEqual(
-            XCTWaiter().wait(for: [becameHittable], timeout: timeout),
-            .completed,
+        XCTWaiter.wait(
+            until: becameHittable,
+            timeout: timeout,
             "\(self) has not became hittable, isHittable:\(isHittable)",
             file: file,
             line: line

--- a/UITests/XCUIElement+Extension.swift
+++ b/UITests/XCUIElement+Extension.swift
@@ -15,13 +15,18 @@ extension XCUIElement {
         XCTAssertEqual(waiter.wait(for: [disappered], timeout: timeout), .completed,
                        "\(self) has not disappeared", file: file, line: line)
     }
+    
     @discardableResult
     func waitToAppear(time timeout: Timeout = .test,
                       file: StaticString = #file,
-                      line: UInt = #line) -> XCUIElement{
-        XCTAssertTrue(waitForExistence(timeout: timeout.rawValue),
+                      line: UInt = #line) -> XCUIElement {
+        XCTAssertTrue(waitForExistence(timeout: timeout),
                       "\(self) has not appeared", file: file, line: line)
         return self
+    }
+    
+    func waitForExistence(timeout: Timeout = .test) -> Bool {
+        waitForExistence(timeout: timeout.rawValue)
     }
 
     @discardableResult

--- a/UITests/ZMoveToApplicationsTest.swift
+++ b/UITests/ZMoveToApplicationsTest.swift
@@ -22,7 +22,7 @@ class ZMoveToApplicationsTest: XCTestCase {
     }
     
     func launchAndChooseToMoveToApplications() {
-        tempApp.launch()
+        moveAppHelper.launch()
         let alert = tempApp.waitForMoveAlert()
         alert.buttons["Move to Applications Folder"].click()
         alert.waitToDisappear()

--- a/UITests/ZMoveToApplicationsTest.swift
+++ b/UITests/ZMoveToApplicationsTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-class MoveToApplicationsTest: XCTestCase {
+class ZMoveToApplicationsTest: XCTestCase {
     let moveAppHelper = MoveAppHelper()
     lazy var tempApp = moveAppHelper.tempApp()
     lazy var movedApp = moveAppHelper.movedApp()


### PR DESCRIPTION
- click on status bar item with retry
- assert there is no `quarantineProperties`
- make move alert independent of preferred applications folder
- refactor MoveAppHelper to use preferred applications folder
- fix test timeout waiting for app to be ready for relaunch